### PR TITLE
Enhancement/check gh repo exists

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"github.com/jackchuka/gh-oss-watch/services"
 )
 
 func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
@@ -14,6 +15,20 @@ func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
 	events := []string{"stars", "issues", "pull_requests", "forks"}
 	if len(eventArgs) > 0 {
 		events = eventArgs
+	}
+
+	owner, repo, err := services.ParseRepoString(repo)
+	if err != nil {
+		return err
+	}
+
+
+	exists, err := c.githubService.RepoExists(owner, repo)
+
+	
+	if !exists {
+		
+		return fmt.Errorf("github repository not found")
 	}
 
 	if err := config.AddRepo(repo, events); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 	"github.com/jackchuka/gh-oss-watch/services"
+	"strings"
 )
 
 func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
@@ -22,12 +22,10 @@ func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
 		return err
 	}
 
-
 	exists, err := c.githubService.RepoExists(owner, repo)
 
-	
 	if !exists {
-		
+
 		return fmt.Errorf("github repository not found")
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,12 +17,12 @@ func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
 		events = eventArgs
 	}
 
-	owner, repo, err := services.ParseRepoString(repo)
+	owner, repoName, err := services.ParseRepoString(repo)
 	if err != nil {
 		return err
 	}
 
-	exists, err := c.githubService.RepoExists(owner, repo)
+	exists, err := c.githubService.RepoExists(owner, repoName)
 
 	if !exists {
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/jackchuka/gh-oss-watch/services"
 	"strings"
+
+	"github.com/jackchuka/gh-oss-watch/services"
 )
 
 func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
@@ -22,11 +23,10 @@ func (c *CLI) handleConfigAdd(repo string, eventArgs []string) error {
 		return err
 	}
 
-	exists, err := c.githubService.RepoExists(owner, repoName)
-
-	if !exists {
-
+	if exists, err := c.githubService.RepoExists(owner, repoName); (err == nil) && !exists {
 		return fmt.Errorf("github repository not found")
+	} else if err != nil {
+		return err
 	}
 
 	if err := config.AddRepo(repo, events); err != nil {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -47,6 +47,32 @@ func TestHandleConfigAdd_Success(t *testing.T) {
 	}
 }
 
+func TestHandleConfigAdd_NotExistingRepo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// testing state
+	repo_str := "notexisting/repo"
+	owner := "notexisting"
+	repoName := "repo"
+
+	mockConfig := mock_services.NewMockConfigService(ctrl)
+	mockCache := mock_services.NewMockCacheService(ctrl)
+	mockGitHub := mock_services.NewMockGitHubService(ctrl)
+	mockOutput := mock_services.NewMockOutput(ctrl)
+
+	cli := NewCLI(mockConfig, mockCache, mockGitHub, mockOutput)
+
+	config := &services.Config{Repos: []services.RepoConfig{}}
+	mockConfig.EXPECT().Load().Return(config, nil)
+	mockGitHub.EXPECT().RepoExists(owner, repoName).Return(false, nil)
+
+	err := cli.handleConfigAdd(repo_str, []string{"invalid_event"})
+
+	if err == nil {
+		t.Error("Expected error for not existing repo, got nil")
+	}
+}
+
 func TestHandleConfigAdd_InvalidEvents(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -20,6 +20,11 @@ func TestHandleConfigAdd_Success(t *testing.T) {
 
 	config := &services.Config{Repos: []services.RepoConfig{}}
 
+	//testing state
+	repo_str := "microsoft/vscode"
+	owner := "microsoft"
+	repoName := "vscode"
+
 	// Set up expectations
 	mockConfig.EXPECT().Load().Return(config, nil)
 	mockConfig.EXPECT().Save(gomock.Any()).DoAndReturn(func(c *services.Config) error {
@@ -27,14 +32,15 @@ func TestHandleConfigAdd_Success(t *testing.T) {
 		if len(c.Repos) != 1 {
 			t.Errorf("Expected 1 repo, got %d", len(c.Repos))
 		}
-		if c.Repos[0].Repo != "owner/repo" {
-			t.Errorf("Expected 'owner/repo', got %s", c.Repos[0].Repo)
+		if c.Repos[0].Repo != repo_str {
+			t.Errorf("Expected '%s', got %s", repo_str, c.Repos[0].Repo)
 		}
 		return nil
 	})
 	mockOutput.EXPECT().Printf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockGitHub.EXPECT().RepoExists(owner, repoName).Return(true, nil)
 
-	err := cli.handleConfigAdd("owner/repo", []string{"stars", "issues"})
+	err := cli.handleConfigAdd(repo_str, []string{"stars", "issues"})
 
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -43,6 +49,11 @@ func TestHandleConfigAdd_Success(t *testing.T) {
 
 func TestHandleConfigAdd_InvalidEvents(t *testing.T) {
 	ctrl := gomock.NewController(t)
+
+	// testing state
+	repo_str := "microsoft/vscode"
+	owner := "microsoft"
+	repoName := "vscode"
 
 	mockConfig := mock_services.NewMockConfigService(ctrl)
 	mockCache := mock_services.NewMockCacheService(ctrl)
@@ -53,8 +64,9 @@ func TestHandleConfigAdd_InvalidEvents(t *testing.T) {
 
 	config := &services.Config{Repos: []services.RepoConfig{}}
 	mockConfig.EXPECT().Load().Return(config, nil)
+	mockGitHub.EXPECT().RepoExists(owner, repoName).Return(true, nil)
 
-	err := cli.handleConfigAdd("owner/repo", []string{"invalid_event"})
+	err := cli.handleConfigAdd(repo_str, []string{"invalid_event"})
 
 	if err == nil {
 		t.Error("Expected error for invalid events, got nil")

--- a/services/concurrent_github_service.go
+++ b/services/concurrent_github_service.go
@@ -39,11 +39,11 @@ func NewConcurrentGitHubService() (BatchGitHubService, error) {
 	}, nil
 }
 
-// RepoExists() is a delegation of RepoExists from baseService 
+// RepoExists() is a delegation of RepoExists from baseService
 func (g *ConcurrentGitHubService) RepoExists(owner, repo string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), g.timeout)
 	defer cancel()
-	
+
 	return g.baseService.RepoExists(ctx, owner, repo)
 }
 
@@ -147,4 +147,3 @@ func (c *ConcurrentGitHubService) SetTimeout(timeout time.Duration) {
 	}
 	c.timeout = timeout
 }
-

--- a/services/concurrent_github_service.go
+++ b/services/concurrent_github_service.go
@@ -39,6 +39,14 @@ func NewConcurrentGitHubService() (BatchGitHubService, error) {
 	}, nil
 }
 
+// RepoExists() is a delegation of RepoExists from baseService 
+func (g *ConcurrentGitHubService) RepoExists(owner, repo string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), g.timeout)
+	defer cancel()
+	
+	return g.baseService.RepoExists(ctx, owner, repo)
+}
+
 func (c *ConcurrentGitHubService) GetRepoStats(owner, repo string) (*RepoStats, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
@@ -139,3 +147,4 @@ func (c *ConcurrentGitHubService) SetTimeout(timeout time.Duration) {
 	}
 	c.timeout = timeout
 }
+

--- a/services/github_base_service.go
+++ b/services/github_base_service.go
@@ -41,6 +41,12 @@ func (g *GitHubBaseService) GetRepoStats(ctx context.Context, owner, repo string
 	}, nil
 }
 
+// RepoExists() checkes repo existance by fetching it
+func (g *GitHubBaseService) RepoExists(ctx context.Context, owner, repo string) (bool, error) {
+	return  g.client.CheckRepoExists(ctx, owner, repo)
+}
+
+
 // ParseRepoString parses a repository string in the format "owner/repo"
 func ParseRepoString(repoStr string) (owner, repo string, err error) {
 	parts := strings.Split(repoStr, "/")
@@ -82,3 +88,4 @@ func CalculateEventSummary(repoStr string, current *RepoStats, previous RepoStat
 
 	return summary
 }
+

--- a/services/github_base_service.go
+++ b/services/github_base_service.go
@@ -43,9 +43,8 @@ func (g *GitHubBaseService) GetRepoStats(ctx context.Context, owner, repo string
 
 // RepoExists() checkes repo existance by fetching it
 func (g *GitHubBaseService) RepoExists(ctx context.Context, owner, repo string) (bool, error) {
-	return  g.client.CheckRepoExists(ctx, owner, repo)
+	return g.client.CheckRepoExists(ctx, owner, repo)
 }
-
 
 // ParseRepoString parses a repository string in the format "owner/repo"
 func ParseRepoString(repoStr string) (owner, repo string, err error) {
@@ -88,4 +87,3 @@ func CalculateEventSummary(repoStr string, current *RepoStats, previous RepoStat
 
 	return summary
 }
-

--- a/services/github_client.go
+++ b/services/github_client.go
@@ -94,7 +94,7 @@ func (c *GitHubAPIClientImpl) GetRepoData(ctx context.Context, owner, repo strin
 func (c *GitHubAPIClientImpl) CheckRepoExists(ctx context.Context, owner, repo string) (bool, error) {
 	repoPath := fmt.Sprintf("repos/%s/%s", owner, repo)
 	var exists bool = false
-	
+
 	err := WithRetry(ctx, c.retryConfig, func() error {
 		resp, err := c.client.RequestWithContext(ctx, "GET", repoPath, nil)
 		if err != nil {
@@ -114,7 +114,7 @@ func (c *GitHubAPIClientImpl) CheckRepoExists(ctx context.Context, owner, repo s
 	if err != nil {
 		return false, err
 	}
-	return  exists, nil
+	return exists, nil
 }
 
 func (c *GitHubAPIClientImpl) GetPullRequests(ctx context.Context, owner, repo string) ([]PullRequestAPIData, error) {

--- a/services/github_service.go
+++ b/services/github_service.go
@@ -41,10 +41,10 @@ func (g *GitHubServiceImpl) SetTimeout(timeout time.Duration) {
 	g.timeout = timeout
 }
 
-// RepoExists() is a delegation of RepoExists from baseService 
+// RepoExists() is a delegation of RepoExists from baseService
 func (g *GitHubServiceImpl) RepoExists(owner, repo string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), g.timeout)
 	defer cancel()
-	
+
 	return g.baseService.RepoExists(ctx, owner, repo)
 }

--- a/services/github_service.go
+++ b/services/github_service.go
@@ -40,3 +40,11 @@ func (g *GitHubServiceImpl) SetTimeout(timeout time.Duration) {
 	}
 	g.timeout = timeout
 }
+
+// RepoExists() is a delegation of RepoExists from baseService 
+func (g *GitHubServiceImpl) RepoExists(owner, repo string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), g.timeout)
+	defer cancel()
+	
+	return g.baseService.RepoExists(ctx, owner, repo)
+}

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -22,12 +22,14 @@ type GitHubAPIClient interface {
 	Get(ctx context.Context, path string, response any) error
 	GetRepoData(ctx context.Context, owner, repo string) (*RepoAPIData, error)
 	GetPullRequests(ctx context.Context, owner, repo string) ([]PullRequestAPIData, error)
+	CheckRepoExists(ctx context.Context, owner, repo string) (bool, error)
 }
 
 type GitHubService interface {
 	GetRepoStats(owner, repo string) (*RepoStats, error)
 	SetMaxConcurrent(maxConcurrent int)
 	SetTimeout(timeout time.Duration)
+	RepoExists(owner, repo string) (bool, error)
 }
 
 type BatchGitHubService interface {

--- a/services/mock/mock_interfaces.go
+++ b/services/mock/mock_interfaces.go
@@ -163,6 +163,21 @@ func (m *MockGitHubAPIClient) EXPECT() *MockGitHubAPIClientMockRecorder {
 	return m.recorder
 }
 
+// CheckRepoExists mocks base method.
+func (m *MockGitHubAPIClient) CheckRepoExists(ctx context.Context, owner, repo string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckRepoExists", ctx, owner, repo)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckRepoExists indicates an expected call of CheckRepoExists.
+func (mr *MockGitHubAPIClientMockRecorder) CheckRepoExists(ctx, owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRepoExists", reflect.TypeOf((*MockGitHubAPIClient)(nil).CheckRepoExists), ctx, owner, repo)
+}
+
 // Get mocks base method.
 func (m *MockGitHubAPIClient) Get(ctx context.Context, path string, response any) error {
 	m.ctrl.T.Helper()
@@ -246,6 +261,21 @@ func (mr *MockGitHubServiceMockRecorder) GetRepoStats(owner, repo any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoStats", reflect.TypeOf((*MockGitHubService)(nil).GetRepoStats), owner, repo)
 }
 
+// RepoExists mocks base method.
+func (m *MockGitHubService) RepoExists(owner, repo string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RepoExists", owner, repo)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RepoExists indicates an expected call of RepoExists.
+func (mr *MockGitHubServiceMockRecorder) RepoExists(owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepoExists", reflect.TypeOf((*MockGitHubService)(nil).RepoExists), owner, repo)
+}
+
 // SetMaxConcurrent mocks base method.
 func (m *MockGitHubService) SetMaxConcurrent(maxConcurrent int) {
 	m.ctrl.T.Helper()
@@ -322,6 +352,21 @@ func (m *MockBatchGitHubService) GetRepoStatsBatch(repos []string) ([]*services.
 func (mr *MockBatchGitHubServiceMockRecorder) GetRepoStatsBatch(repos any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoStatsBatch", reflect.TypeOf((*MockBatchGitHubService)(nil).GetRepoStatsBatch), repos)
+}
+
+// RepoExists mocks base method.
+func (m *MockBatchGitHubService) RepoExists(owner, repo string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RepoExists", owner, repo)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RepoExists indicates an expected call of RepoExists.
+func (mr *MockBatchGitHubServiceMockRecorder) RepoExists(owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepoExists", reflect.TypeOf((*MockBatchGitHubService)(nil).RepoExists), owner, repo)
 }
 
 // SetMaxConcurrent mocks base method.


### PR DESCRIPTION
The issue: https://github.com/jackchuka/gh-oss-watch/issues/2

## Summary

This pull request adds repository existence validation when adding a new GitHub repo to the config.

### Changes

- Added `CheckRepoExists` method to `GitHubAPIClient`
- Integrated `RepoExists` check into the CLI `add` command via `GitHubBaseService`
- Delegated `RepoExists` implementation to both `GitHubServiceImpl` and `ConcurrentGitHubService`
- Refactored and cleaned up formatting in service files
- Added mock methods for `CheckRepoExists` and `RepoExists` in tests
- Updated `TestHandleConfigAdd_Success` to include the new existence check
- Added `TestHandleConfigAdd_NotExistingRepo` to verify behavior with non-existing repositories
- Fixed error handling and reordered repository existence check logic
