### PR TITLE
feat: add repo language tracking and list command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -41,13 +41,14 @@ func handleConfigAdd(configService services.ConfigService, githubService service
 		return err
 	}
 
-	if err := githubService.RepoExists(owner, repoName); err != nil {
+	repoData, err := githubService.GetRepoInfo(owner, repoName)
+	if err != nil {
 		return fmt.Errorf("repository does not exist or is inaccessible: %w", err)
 	}
 
 	normalized := owner + "/" + repoName
 
-	if err := config.AddRepo(normalized, events); err != nil {
+	if err := config.AddRepo(normalized, events, repoData.Language); err != nil {
 		return err
 	}
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -24,13 +24,16 @@ func TestHandleConfigAdd(t *testing.T) {
 			setup: func(mc *mock_services.MockConfigService, mg *mock_services.MockGitHubService) {
 				config := &services.Config{Repos: []services.RepoConfig{}}
 				mc.EXPECT().Load().Return(config, nil)
-				mg.EXPECT().RepoExists("microsoft", "vscode").Return(nil)
+				mg.EXPECT().GetRepoInfo("microsoft", "vscode").Return(&services.RepoAPIData{Language: "TypeScript"}, nil)
 				mc.EXPECT().Save(gomock.Any()).DoAndReturn(func(c *services.Config) error {
 					if len(c.Repos) != 1 {
 						t.Errorf("expected 1 repo, got %d", len(c.Repos))
 					}
 					if c.Repos[0].Repo != "microsoft/vscode" {
 						t.Errorf("expected 'microsoft/vscode', got %s", c.Repos[0].Repo)
+					}
+					if c.Repos[0].Language != "TypeScript" {
+						t.Errorf("expected language 'TypeScript', got %s", c.Repos[0].Language)
 					}
 					return nil
 				})
@@ -43,7 +46,7 @@ func TestHandleConfigAdd(t *testing.T) {
 			setup: func(mc *mock_services.MockConfigService, mg *mock_services.MockGitHubService) {
 				config := &services.Config{Repos: []services.RepoConfig{}}
 				mc.EXPECT().Load().Return(config, nil)
-				mg.EXPECT().RepoExists("notexisting", "repo").Return(errors.New("not found"))
+				mg.EXPECT().GetRepoInfo("notexisting", "repo").Return(nil, errors.New("not found"))
 			},
 			wantErr: true,
 		},
@@ -54,7 +57,7 @@ func TestHandleConfigAdd(t *testing.T) {
 			setup: func(mc *mock_services.MockConfigService, mg *mock_services.MockGitHubService) {
 				config := &services.Config{Repos: []services.RepoConfig{}}
 				mc.EXPECT().Load().Return(config, nil)
-				mg.EXPECT().RepoExists("microsoft", "vscode").Return(nil)
+				mg.EXPECT().GetRepoInfo("microsoft", "vscode").Return(&services.RepoAPIData{}, nil)
 			},
 			wantErr: true,
 		},

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -6,11 +6,17 @@ import (
 )
 
 type dashboardProcessor struct {
-	entries []services.DashboardEntry
-	totals  services.DashboardTotals
+	entries   []services.DashboardEntry
+	totals    services.DashboardTotals
+	repoStats []*services.RepoStats
 }
 
 func (d *dashboardProcessor) ProcessRepo(repoConfig services.RepoConfig, stats *services.RepoStats, index int) error {
+	for len(d.repoStats) <= index {
+		d.repoStats = append(d.repoStats, nil)
+	}
+	d.repoStats[index] = stats
+
 	d.entries = append(d.entries, services.DashboardEntry{
 		Repo:            repoConfig.Repo,
 		Stars:           stats.Stars,
@@ -66,6 +72,8 @@ func handleDashboard(configService services.ConfigService, githubService service
 	if err != nil {
 		return err
 	}
+
+	backfillLanguages(configService, config, processor.repoStats)
 
 	return formatter.RenderDashboard(services.DashboardResult{
 		Repos:  processor.entries,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/jackchuka/gh-oss-watch/services"
+	"github.com/spf13/cobra"
+)
+
+var lang string
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List tracked repos",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return handleList(services.NewConfigService(), newFormatter(), lang)
+	},
+}
+
+func init() {
+	listCmd.Flags().StringVarP(&lang, "lang", "l", "", "Filter by language (case-insensitive)")
+	rootCmd.AddCommand(listCmd)
+}
+
+func handleList(configService services.ConfigService, formatter services.Formatter, langFilter string) error {
+	config, err := configService.Load()
+	if err != nil {
+		return err
+	}
+
+	repos := config.Repos
+	if langFilter != "" {
+		filtered := make([]services.RepoConfig, 0, len(repos))
+		for _, r := range repos {
+			if strings.EqualFold(r.Language, langFilter) {
+				filtered = append(filtered, r)
+			}
+		}
+		repos = filtered
+	}
+
+	return formatter.RenderList(services.ListResult{
+		Repos: repos,
+		Total: len(repos),
+	})
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackchuka/gh-oss-watch/services"
+	mock_services "github.com/jackchuka/gh-oss-watch/services/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHandleList(t *testing.T) {
+	tests := []struct {
+		name    string
+		lang    string
+		format  string
+		setup   func(*mock_services.MockConfigService)
+		check   func(t *testing.T, out string)
+		wantErr bool
+	}{
+		{
+			name:   "lists all repos",
+			lang:   "",
+			format: "plain",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "facebook/react", Events: []string{"stars", "issues"}, Language: "JavaScript"},
+					{Repo: "golang/go", Events: []string{"stars", "forks"}, Language: "Go"},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				for _, s := range []string{"facebook/react", "JavaScript", "golang/go", "Go"} {
+					if !contains(out, s) {
+						t.Errorf("expected output to contain %q, got:\n%s", s, out)
+					}
+				}
+			},
+		},
+		{
+			name:   "filters by language case-insensitive",
+			lang:   "go",
+			format: "plain",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "facebook/react", Events: []string{"stars"}, Language: "JavaScript"},
+					{Repo: "golang/go", Events: []string{"stars"}, Language: "Go"},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				if !contains(out, "golang/go") {
+					t.Errorf("expected output to contain 'golang/go', got:\n%s", out)
+				}
+				if contains(out, "facebook/react") {
+					t.Errorf("expected output NOT to contain 'facebook/react', got:\n%s", out)
+				}
+			},
+		},
+		{
+			name:   "unknown lang returns empty list",
+			lang:   "rust",
+			format: "plain",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "golang/go", Events: []string{"stars"}, Language: "Go"},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				if contains(out, "golang/go") {
+					t.Errorf("expected empty output, got:\n%s", out)
+				}
+			},
+		},
+		{
+			name:   "empty config",
+			lang:   "",
+			format: "plain",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				if contains(out, "REPO") {
+					t.Errorf("expected no table header for empty config, got:\n%s", out)
+				}
+			},
+		},
+		{
+			name:   "json output with wrapper",
+			lang:   "",
+			format: "json",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "golang/go", Events: []string{"stars"}, Language: "Go"},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(out), &result); err != nil {
+					t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+				}
+				if _, ok := result["repos"]; !ok {
+					t.Error("expected 'repos' key in JSON output")
+				}
+				if total, ok := result["total"]; !ok || total != float64(1) {
+					t.Errorf("expected total=1, got %v", total)
+				}
+			},
+		},
+		{
+			name:   "json output with lang filter",
+			lang:   "go",
+			format: "json",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "facebook/react", Events: []string{"stars"}, Language: "JavaScript"},
+					{Repo: "golang/go", Events: []string{"stars"}, Language: "Go"},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				var result map[string]any
+				if err := json.Unmarshal([]byte(out), &result); err != nil {
+					t.Fatalf("output is not valid JSON: %v", err)
+				}
+				if total := result["total"]; total != float64(1) {
+					t.Errorf("expected total=1 after filter, got %v", total)
+				}
+			},
+		},
+		{
+			name:   "repo with no language shows dash in plain",
+			lang:   "",
+			format: "plain",
+			setup: func(mc *mock_services.MockConfigService) {
+				config := &services.Config{Repos: []services.RepoConfig{
+					{Repo: "owner/config-only", Events: []string{"stars"}, Language: ""},
+				}}
+				mc.EXPECT().Load().Return(config, nil)
+			},
+			check: func(t *testing.T, out string) {
+				if !contains(out, "-") {
+					t.Errorf("expected '-' for empty language, got:\n%s", out)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockConfig := mock_services.NewMockConfigService(ctrl)
+			tt.setup(mockConfig)
+
+			var buf bytes.Buffer
+			var formatter services.Formatter
+			if tt.format == "json" {
+				formatter = services.NewJSONFormatter(&buf)
+			} else {
+				formatter = services.NewPlainFormatter(&buf, false, 120)
+			}
+
+			err := handleList(mockConfig, formatter, tt.lang)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, buf.String())
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && bytes.Contains([]byte(s), []byte(substr))
+}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -36,7 +36,7 @@ func handleConfigSet(configService services.ConfigService, repo string, eventArg
 		return fmt.Errorf("repository %s not found in config. Use 'gh oss-watch add' first", repo)
 	}
 
-	if err := config.AddRepo(repo, eventArgs); err != nil {
+	if err := config.AddRepo(repo, eventArgs, ""); err != nil {
 		return err
 	}
 

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -61,6 +61,24 @@ func processReposWithBatch(
 	return nil
 }
 
+func backfillLanguages(configService services.ConfigService, config *services.Config, allStats []*services.RepoStats) {
+	needsSave := false
+	for i, repoConfig := range config.Repos {
+		if repoConfig.Language != "" {
+			continue
+		}
+		if i < len(allStats) && allStats[i] != nil && allStats[i].Language != "" {
+			config.Repos[i].Language = allStats[i].Language
+			needsSave = true
+		}
+	}
+	if needsSave {
+		if err := configService.Save(config); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to backfill language info: %v\n", err)
+		}
+	}
+}
+
 func processReposSequentially(
 	githubService services.GitHubService,
 	config *services.Config,

--- a/cmd/shared_test.go
+++ b/cmd/shared_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackchuka/gh-oss-watch/services"
+	mock_services "github.com/jackchuka/gh-oss-watch/services/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBackfillLanguages(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *services.Config
+		stats         []*services.RepoStats
+		expectSave    bool
+		saveShouldErr bool
+		wantLangs     []string
+	}{
+		{
+			name: "backfills empty language from stats",
+			config: &services.Config{Repos: []services.RepoConfig{
+				{Repo: "owner/repo", Events: []string{"stars"}, Language: ""},
+			}},
+			stats:      []*services.RepoStats{{Language: "Go"}},
+			expectSave: true,
+			wantLangs:  []string{"Go"},
+		},
+		{
+			name: "skips repos that already have language",
+			config: &services.Config{Repos: []services.RepoConfig{
+				{Repo: "owner/repo", Events: []string{"stars"}, Language: "Go"},
+			}},
+			stats:      []*services.RepoStats{{Language: "Go"}},
+			expectSave: false,
+			wantLangs:  []string{"Go"},
+		},
+		{
+			name: "skips nil stats",
+			config: &services.Config{Repos: []services.RepoConfig{
+				{Repo: "owner/repo", Events: []string{"stars"}, Language: ""},
+			}},
+			stats:      []*services.RepoStats{nil},
+			expectSave: false,
+			wantLangs:  []string{""},
+		},
+		{
+			name: "save failure does not panic",
+			config: &services.Config{Repos: []services.RepoConfig{
+				{Repo: "owner/repo", Events: []string{"stars"}, Language: ""},
+			}},
+			stats:         []*services.RepoStats{{Language: "Go"}},
+			expectSave:    true,
+			saveShouldErr: true,
+			wantLangs:     []string{"Go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockConfig := mock_services.NewMockConfigService(ctrl)
+
+			if tt.expectSave {
+				if tt.saveShouldErr {
+					mockConfig.EXPECT().Save(gomock.Any()).Return(fmt.Errorf("save failed"))
+				} else {
+					mockConfig.EXPECT().Save(gomock.Any()).Return(nil)
+				}
+			}
+
+			backfillLanguages(mockConfig, tt.config, tt.stats)
+
+			for i, want := range tt.wantLangs {
+				if tt.config.Repos[i].Language != want {
+					t.Errorf("repo %d: expected language %q, got %q", i, want, tt.config.Repos[i].Language)
+				}
+			}
+		})
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,11 +10,17 @@ import (
 )
 
 type statusProcessor struct {
-	cache   *services.CacheData
-	entries []services.StatusEntry
+	cache     *services.CacheData
+	entries   []services.StatusEntry
+	repoStats []*services.RepoStats
 }
 
 func (s *statusProcessor) ProcessRepo(repoConfig services.RepoConfig, stats *services.RepoStats, index int) error {
+	for len(s.repoStats) <= index {
+		s.repoStats = append(s.repoStats, nil)
+	}
+	s.repoStats[index] = stats
+
 	previousState, exists := s.cache.Repos[repoConfig.Repo]
 	if !exists {
 		previousState = services.RepoState{}
@@ -100,6 +106,8 @@ func handleStatus(configService services.ConfigService, cacheService services.Ca
 	if err != nil {
 		return err
 	}
+
+	backfillLanguages(configService, config, processor.repoStats)
 
 	if err := formatter.RenderStatus(processor.entries); err != nil {
 		return err

--- a/services/concurrent_github_service.go
+++ b/services/concurrent_github_service.go
@@ -39,12 +39,10 @@ func NewConcurrentGitHubService() (BatchGitHubService, error) {
 	}, nil
 }
 
-// RepoExists() is a delegation of RepoExists from baseService
-func (g *ConcurrentGitHubService) RepoExists(owner, repo string) error {
+func (g *ConcurrentGitHubService) GetRepoInfo(owner, repo string) (*RepoAPIData, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), g.timeout)
 	defer cancel()
-
-	return g.baseService.RepoExists(ctx, owner, repo)
+	return g.baseService.GetRepoInfo(ctx, owner, repo)
 }
 
 func (c *ConcurrentGitHubService) GetRepoStats(owner, repo string) (*RepoStats, error) {

--- a/services/config_service.go
+++ b/services/config_service.go
@@ -94,19 +94,23 @@ func validateEvents(events []string) error {
 	return nil
 }
 
-func (c *Config) AddRepo(repo string, events []string) error {
+func (c *Config) AddRepo(repo string, events []string, language string) error {
 	if err := validateEvents(events); err != nil {
 		return err
 	}
 	for i, r := range c.Repos {
 		if r.Repo == repo {
 			c.Repos[i].Events = events
+			if language != "" {
+				c.Repos[i].Language = language
+			}
 			return nil
 		}
 	}
 	c.Repos = append(c.Repos, RepoConfig{
-		Repo:   repo,
-		Events: events,
+		Repo:     repo,
+		Events:   events,
+		Language: language,
 	})
 	return nil
 }

--- a/services/github_base_service.go
+++ b/services/github_base_service.go
@@ -39,6 +39,7 @@ func (g *GitHubBaseService) GetRepoStats(ctx context.Context, owner, repo string
 		Forks:         repoData.ForksCount,
 		UpdatedAt:     repoData.UpdatedAt,
 		DefaultBranch: repoData.DefaultBranch,
+		Language:      repoData.Language,
 	}
 
 	release, err := g.client.GetLatestRelease(ctx, owner, repo)
@@ -60,12 +61,8 @@ func (g *GitHubBaseService) GetRepoStats(ctx context.Context, owner, repo string
 	return stats, nil
 }
 
-// RepoExists() checkes repo existance by fetching it
-func (g *GitHubBaseService) RepoExists(ctx context.Context, owner, repo string) error {
-	if _, err := g.client.GetRepoData(ctx, owner, repo); err != nil {
-		return err
-	}
-	return nil
+func (g *GitHubBaseService) GetRepoInfo(ctx context.Context, owner, repo string) (*RepoAPIData, error) {
+	return g.client.GetRepoData(ctx, owner, repo)
 }
 
 // ParseRepoString parses a repository string into owner and repo.

--- a/services/github_client.go
+++ b/services/github_client.go
@@ -19,6 +19,7 @@ type RepoAPIData struct {
 	OpenIssuesCount int       `json:"open_issues_count"`
 	UpdatedAt       time.Time `json:"updated_at"`
 	DefaultBranch   string    `json:"default_branch"`
+	Language        string    `json:"language"`
 }
 
 type OwnerData struct {

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -30,7 +30,7 @@ type GitHubAPIClient interface {
 type GitHubService interface {
 	GetRepoStats(owner, repo string) (*RepoStats, error)
 	SetMaxConcurrent(maxConcurrent int)
-	RepoExists(owner, repo string) error
+	GetRepoInfo(owner, repo string) (*RepoAPIData, error)
 	SetTimeout(timeout time.Duration)
 }
 
@@ -53,8 +53,9 @@ type Config struct {
 }
 
 type RepoConfig struct {
-	Repo   string   `yaml:"repo"`
-	Events []string `yaml:"events"`
+	Repo     string   `yaml:"repo" json:"repo"`
+	Events   []string `yaml:"events" json:"events"`
+	Language string   `yaml:"language,omitempty" json:"language"`
 }
 
 type CacheData struct {
@@ -83,6 +84,7 @@ type RepoStats struct {
 	ReleaseDate     time.Time
 	UnreleasedCount int
 	DefaultBranch   string
+	Language        string
 }
 
 type EventSummary struct {
@@ -152,9 +154,15 @@ type FansResult struct {
 	TotalStars int        `json:"totalStars"`
 }
 
+type ListResult struct {
+	Repos []RepoConfig `json:"repos"`
+	Total int          `json:"total"`
+}
+
 type Formatter interface {
 	RenderStatus(entries []StatusEntry) error
 	RenderDashboard(result DashboardResult) error
 	RenderReleases(releases []ReleaseInfo) error
 	RenderFans(result FansResult) error
+	RenderList(result ListResult) error
 }

--- a/services/json_formatter.go
+++ b/services/json_formatter.go
@@ -37,3 +37,10 @@ func (f *JSONFormatter) RenderFans(result FansResult) error {
 	}
 	return json.NewEncoder(f.w).Encode(result)
 }
+
+func (f *JSONFormatter) RenderList(result ListResult) error {
+	if result.Repos == nil {
+		result.Repos = []RepoConfig{}
+	}
+	return json.NewEncoder(f.w).Encode(result)
+}

--- a/services/json_formatter_test.go
+++ b/services/json_formatter_test.go
@@ -375,6 +375,104 @@ func TestJSONFormatter_RenderFans(t *testing.T) {
 	}
 }
 
+func TestJSONFormatter_RenderList(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ListResult
+		check  func(t *testing.T, got map[string]any)
+	}{
+		{
+			name: "with repos produces valid JSON with repos and total",
+			result: ListResult{
+				Repos: []RepoConfig{
+					{Repo: "golang/go", Language: "Go", Events: []string{"stars"}},
+				},
+				Total: 1,
+			},
+			check: func(t *testing.T, got map[string]any) {
+				repos, ok := got["repos"].([]any)
+				if !ok {
+					t.Fatalf("'repos' should be an array, got %T", got["repos"])
+				}
+				if len(repos) != 1 {
+					t.Fatalf("expected 1 repo, got %d", len(repos))
+				}
+				repo := repos[0].(map[string]any)
+				assertEqual(t, "golang/go", repo["repo"])
+				assertEqual(t, "Go", repo["language"])
+				assertEqual(t, float64(1), got["total"])
+			},
+		},
+		{
+			name: "empty repos produces empty array not null",
+			result: ListResult{
+				Repos: []RepoConfig{},
+				Total: 0,
+			},
+			check: func(t *testing.T, got map[string]any) {
+				repos, ok := got["repos"].([]any)
+				if !ok {
+					t.Fatalf("'repos' should be an array, got %T", got["repos"])
+				}
+				if len(repos) != 0 {
+					t.Fatalf("expected 0 repos, got %d", len(repos))
+				}
+				assertEqual(t, float64(0), got["total"])
+			},
+		},
+		{
+			name:   "nil repos produces empty array not null",
+			result: ListResult{},
+			check: func(t *testing.T, got map[string]any) {
+				repos, ok := got["repos"].([]any)
+				if !ok {
+					t.Fatalf("'repos' should be an array, got %T", got["repos"])
+				}
+				if len(repos) != 0 {
+					t.Fatalf("expected 0 repos, got %d", len(repos))
+				}
+			},
+		},
+		{
+			name: "empty language renders as empty string not omitted",
+			result: ListResult{
+				Repos: []RepoConfig{
+					{Repo: "owner/repo", Language: "", Events: []string{"stars"}},
+				},
+				Total: 1,
+			},
+			check: func(t *testing.T, got map[string]any) {
+				repos := got["repos"].([]any)
+				repo := repos[0].(map[string]any)
+				lang, ok := repo["language"]
+				if !ok {
+					t.Fatal("expected 'language' key to be present in JSON output")
+				}
+				assertEqual(t, "", lang)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			f := NewJSONFormatter(&buf)
+
+			err := f.RenderList(tt.result)
+			if err != nil {
+				t.Fatalf("RenderList returned error: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+			}
+
+			tt.check(t, got)
+		})
+	}
+}
+
 func assertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if expected != actual {

--- a/services/mock/mock_interfaces.go
+++ b/services/mock/mock_interfaces.go
@@ -276,6 +276,21 @@ func (m *MockGitHubService) EXPECT() *MockGitHubServiceMockRecorder {
 	return m.recorder
 }
 
+// GetRepoInfo mocks base method.
+func (m *MockGitHubService) GetRepoInfo(owner, repo string) (*services.RepoAPIData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepoInfo", owner, repo)
+	ret0, _ := ret[0].(*services.RepoAPIData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepoInfo indicates an expected call of GetRepoInfo.
+func (mr *MockGitHubServiceMockRecorder) GetRepoInfo(owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoInfo", reflect.TypeOf((*MockGitHubService)(nil).GetRepoInfo), owner, repo)
+}
+
 // GetRepoStats mocks base method.
 func (m *MockGitHubService) GetRepoStats(owner, repo string) (*services.RepoStats, error) {
 	m.ctrl.T.Helper()
@@ -289,20 +304,6 @@ func (m *MockGitHubService) GetRepoStats(owner, repo string) (*services.RepoStat
 func (mr *MockGitHubServiceMockRecorder) GetRepoStats(owner, repo any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoStats", reflect.TypeOf((*MockGitHubService)(nil).GetRepoStats), owner, repo)
-}
-
-// RepoExists mocks base method.
-func (m *MockGitHubService) RepoExists(owner, repo string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RepoExists", owner, repo)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RepoExists indicates an expected call of RepoExists.
-func (mr *MockGitHubServiceMockRecorder) RepoExists(owner, repo any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepoExists", reflect.TypeOf((*MockGitHubService)(nil).RepoExists), owner, repo)
 }
 
 // SetMaxConcurrent mocks base method.
@@ -353,6 +354,21 @@ func (m *MockBatchGitHubService) EXPECT() *MockBatchGitHubServiceMockRecorder {
 	return m.recorder
 }
 
+// GetRepoInfo mocks base method.
+func (m *MockBatchGitHubService) GetRepoInfo(owner, repo string) (*services.RepoAPIData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepoInfo", owner, repo)
+	ret0, _ := ret[0].(*services.RepoAPIData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepoInfo indicates an expected call of GetRepoInfo.
+func (mr *MockBatchGitHubServiceMockRecorder) GetRepoInfo(owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoInfo", reflect.TypeOf((*MockBatchGitHubService)(nil).GetRepoInfo), owner, repo)
+}
+
 // GetRepoStats mocks base method.
 func (m *MockBatchGitHubService) GetRepoStats(owner, repo string) (*services.RepoStats, error) {
 	m.ctrl.T.Helper()
@@ -381,20 +397,6 @@ func (m *MockBatchGitHubService) GetRepoStatsBatch(repos []string) ([]*services.
 func (mr *MockBatchGitHubServiceMockRecorder) GetRepoStatsBatch(repos any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoStatsBatch", reflect.TypeOf((*MockBatchGitHubService)(nil).GetRepoStatsBatch), repos)
-}
-
-// RepoExists mocks base method.
-func (m *MockBatchGitHubService) RepoExists(owner, repo string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RepoExists", owner, repo)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RepoExists indicates an expected call of RepoExists.
-func (mr *MockBatchGitHubServiceMockRecorder) RepoExists(owner, repo any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepoExists", reflect.TypeOf((*MockBatchGitHubService)(nil).RepoExists), owner, repo)
 }
 
 // SetMaxConcurrent mocks base method.
@@ -567,6 +569,20 @@ func (m *MockFormatter) RenderFans(result services.FansResult) error {
 func (mr *MockFormatterMockRecorder) RenderFans(result any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderFans", reflect.TypeOf((*MockFormatter)(nil).RenderFans), result)
+}
+
+// RenderList mocks base method.
+func (m *MockFormatter) RenderList(result services.ListResult) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenderList", result)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenderList indicates an expected call of RenderList.
+func (mr *MockFormatterMockRecorder) RenderList(result any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderList", reflect.TypeOf((*MockFormatter)(nil).RenderList), result)
 }
 
 // RenderReleases mocks base method.

--- a/services/plain_formatter.go
+++ b/services/plain_formatter.go
@@ -252,6 +252,29 @@ func (f *PlainFormatter) RenderFans(result FansResult) error {
 	return err
 }
 
+func (f *PlainFormatter) RenderList(result ListResult) error {
+	if len(result.Repos) == 0 {
+		_, err := fmt.Fprintln(f.w, "No repos tracked. Use 'gh oss-watch add <repo>' to add some.")
+		return err
+	}
+
+	tp := tableprinter.New(f.w, f.isTTY, f.maxWidth)
+	tp.AddHeader([]string{"Repo", "Language", "Events"})
+
+	for _, r := range result.Repos {
+		tp.AddField(r.Repo, tableprinter.WithColor(f.bold()))
+		lang := r.Language
+		if lang == "" {
+			lang = "-"
+		}
+		tp.AddField(lang)
+		tp.AddField(strings.Join(r.Events, ", "), tableprinter.WithColor(f.dim()))
+		tp.EndRow()
+	}
+
+	return tp.Render()
+}
+
 func (f *PlainFormatter) hasEvent(events []string, event string) bool {
 	for _, e := range events {
 		if e == event {

--- a/services/plain_formatter_test.go
+++ b/services/plain_formatter_test.go
@@ -177,6 +177,63 @@ func TestPlainFormatter_RenderFans(t *testing.T) {
 	}
 }
 
+func TestPlainFormatter_RenderList(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   ListResult
+		contains []string
+	}{
+		{
+			name: "with repos shows table with language and events",
+			result: ListResult{
+				Repos: []RepoConfig{
+					{Repo: "facebook/react", Language: "JavaScript", Events: []string{"stars", "issues"}},
+					{Repo: "golang/go", Language: "Go", Events: []string{"stars", "forks"}},
+				},
+				Total: 2,
+			},
+			contains: []string{"facebook/react", "JavaScript", "golang/go", "Go", "stars, issues", "stars, forks"},
+		},
+		{
+			name: "empty language shows dash",
+			result: ListResult{
+				Repos: []RepoConfig{
+					{Repo: "owner/repo", Language: "", Events: []string{"stars"}},
+				},
+				Total: 1,
+			},
+			contains: []string{"owner/repo", "-"},
+		},
+		{
+			name: "empty repos shows no repos message",
+			result: ListResult{
+				Repos: []RepoConfig{},
+				Total: 0,
+			},
+			contains: []string{"No repos"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			f := NewPlainFormatter(&buf, false, 120)
+
+			err := f.RenderList(tt.result)
+			if err != nil {
+				t.Fatalf("RenderList returned error: %v", err)
+			}
+
+			out := buf.String()
+			for _, s := range tt.contains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected output to contain %q, got:\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
 func TestPlainFormatter_RenderReleases(t *testing.T) {
 	releases := []ReleaseInfo{
 		{


### PR DESCRIPTION
## Summary

- Track each repo's primary programming language (fetched from GitHub API on `add`, backfilled on `status`/`dashboard`)
- Add `list` command to display tracked repos with `--lang` filter for filtering by language
- Support both plain text (table) and JSON output formats

## Changes

**Data model:**
- Add `Language` field to `RepoConfig`, `RepoStats`, `RepoAPIData`
- Rename `RepoExists` → `GetRepoInfo` to return repo data (including language) instead of discarding it
- `AddRepo` now accepts a language parameter; preserves existing language on events-only updates

**New command:**
- `gh oss-watch list` — lists all tracked repos with language and events
- `gh oss-watch list --lang go` — case-insensitive filter by language
- Works with `--format json` (wrapper: `{"repos": [...], "total": N}`)

**Backfill:**
- `status` and `dashboard` commands backfill empty language from API responses (best-effort, won't fail the command)

## Test plan

- [x] `list` with empty config → shows "no repos" message
- [x] `list` shows all repos in config order with language and events
- [x] `--lang` filter is case-insensitive, applies to both plain and JSON
- [x] Unknown `--lang` value → empty list, no error
- [x] Empty language renders as `-` in plain, `""` in JSON (not omitted)
- [x] `add` stores language from GitHub API
- [x] Backfill updates empty language after status/dashboard
- [x] Backfill save failure doesn't break the command
- [x] All 101 tests passing, `go vet` clean