### PR TITLE
feat(api): enable go-gh built-in HTTP cache with 1m TTL

### DIFF
--- a/services/github_client.go
+++ b/services/github_client.go
@@ -56,7 +56,10 @@ type GitHubAPIClientImpl struct {
 }
 
 func NewGitHubAPIClient() (GitHubAPIClient, error) {
-	restClient, err := api.DefaultRESTClient()
+	restClient, err := api.NewRESTClient(api.ClientOptions{
+		EnableCache: true,
+		CacheTTL:    1 * time.Minute,
+	})
 	if err != nil {
 		return nil, NewConfigError("failed to create GitHub API client", err)
 	}


### PR DESCRIPTION
## Summary
- Enable go-gh's built-in HTTP transport cache on the REST client with a 1-minute TTL
- All GET and GraphQL POST requests are cached automatically at the transport layer
- Reduces redundant GitHub API calls when commands are run in quick succession

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Run `gh oss-watch status` twice within 1 minute and confirm second run is faster