### PR TITLE
feat: add `security` command — cross-repo Dependabot alert snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ go build -o gh-oss-watch .
 | `remove <repo>`          | Remove repo from watch list        | `gh oss-watch remove owner/repo`           |
 | `status`                 | Show new activity since last check | `gh oss-watch status`                      |
 | `dashboard`              | Display summary across all repos   | `gh oss-watch dashboard`                   |
+| `security`               | Show open Dependabot alerts across repos | `gh oss-watch security --detail`     |
 
 ## Event Types
 
@@ -78,6 +79,24 @@ go build -o gh-oss-watch .
 - **`issues`** - Issues created/reopened
 - **`pull_requests`** - Pull requests opened
 - **`forks`** - Repository forks
+
+## Security
+
+`gh oss-watch security` scans your watch list for open Dependabot alerts and prints a
+severity-ranked snapshot (a point-in-time view, not a since-last-check diff — an open
+alert stays relevant until it's fixed). Add `--detail` for per-alert lines,
+`--severity high` to show only alerts at or above a minimum severity, or
+`--repo owner/name` to limit to a single watched repo. Repos you can't read alerts on
+(un-owned, or with alerts disabled) are listed as skipped. Use `--format json` for
+machine-readable output.
+
+```bash
+gh oss-watch security                       # severity-ranked summary table
+gh oss-watch security --detail              # every alert (package, range, fix, GHSA)
+gh oss-watch security --severity high       # only high + critical
+gh oss-watch security --repo owner/repo     # a single watched repo
+gh oss-watch security --format json         # machine-readable
+```
 
 ## Configuration
 

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jackchuka/gh-oss-watch/services"
+	"github.com/spf13/cobra"
+)
+
+var (
+	securityDetail   bool
+	securitySeverity string
+	securityRepo     string
+)
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Show open Dependabot security alerts across all repos",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		githubService, err := newGitHubService()
+		if err != nil {
+			return err
+		}
+		return handleSecurity(services.NewConfigService(), githubService, newFormatter(), securityDetail, securitySeverity, securityRepo)
+	},
+}
+
+func init() {
+	securityCmd.Flags().BoolVarP(&securityDetail, "detail", "d", false, "Show every alert, not just per-repo counts")
+	securityCmd.Flags().StringVarP(&securitySeverity, "severity", "s", "", "Only show alerts at or above this severity: critical, high, medium, low")
+	securityCmd.Flags().StringVarP(&securityRepo, "repo", "r", "", "Limit to a single watched repo (owner/name)")
+	rootCmd.AddCommand(securityCmd)
+}
+
+func handleSecurity(configService services.ConfigService, githubService services.BatchGitHubService, formatter services.Formatter, detail bool, severityFloor, repoFilter string) error {
+	config, err := validateConfig(configService)
+	if err != nil {
+		return err
+	}
+	if len(config.Repos) == 0 {
+		return nil
+	}
+
+	if err := validateSecurityFlags(config, severityFloor, repoFilter); err != nil {
+		return err
+	}
+
+	repos := selectSecurityRepos(config, repoFilter)
+
+	alertService, ok := githubService.(services.DependabotAlertsBatchService)
+	if !ok {
+		return fmt.Errorf("github service does not support alert scanning")
+	}
+
+	alertsPerRepo, errs := alertService.GetDependabotAlertsBatch(repos)
+
+	for i, repo := range repos {
+		if i < len(errs) && errs[i] != nil && !errors.Is(errs[i], services.ErrNoAlertAccess) {
+			fmt.Fprintf(os.Stderr, "Error fetching alerts for %s: %v\n", repo, errs[i])
+		}
+	}
+
+	result := services.BuildSecurityResult(repos, alertsPerRepo, errs, severityFloor)
+	return formatter.RenderSecurity(result, detail)
+}
+
+func selectSecurityRepos(config *services.Config, repoFilter string) []string {
+	if repoFilter != "" {
+		return []string{repoFilter}
+	}
+	repos := make([]string, len(config.Repos))
+	for i, rc := range config.Repos {
+		repos[i] = rc.Repo
+	}
+	return repos
+}
+
+func validateSecurityFlags(config *services.Config, severityFloor, repoFilter string) error {
+	switch severityFloor {
+	case "", "critical", "high", "medium", "low":
+	default:
+		return fmt.Errorf("invalid --severity %q: must be one of critical, high, medium, low", severityFloor)
+	}
+
+	if repoFilter != "" {
+		found := false
+		for _, rc := range config.Repos {
+			if rc.Repo == repoFilter {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("repo %q is not in your watch list (use 'gh oss-watch add %s')", repoFilter, repoFilter)
+		}
+	}
+
+	return nil
+}

--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/jackchuka/gh-oss-watch/services"
+)
+
+func cfg(repos ...string) *services.Config {
+	c := &services.Config{}
+	for _, r := range repos {
+		c.Repos = append(c.Repos, services.RepoConfig{Repo: r})
+	}
+	return c
+}
+
+func TestValidateSecurityFlags(t *testing.T) {
+	config := cfg("jackchuka/timestack")
+
+	if err := validateSecurityFlags(config, "high", "jackchuka/timestack"); err != nil {
+		t.Errorf("valid input errored: %v", err)
+	}
+	if err := validateSecurityFlags(config, "", ""); err != nil {
+		t.Errorf("empty input errored: %v", err)
+	}
+	if err := validateSecurityFlags(config, "bogus", ""); err == nil {
+		t.Error("expected error for invalid severity")
+	}
+	if err := validateSecurityFlags(config, "", "jackchuka/not-watched"); err == nil {
+		t.Error("expected error for un-watched repo")
+	}
+}
+
+func TestSelectSecurityRepos(t *testing.T) {
+	config := cfg("o/a", "o/b")
+	if got := selectSecurityRepos(config, ""); len(got) != 2 {
+		t.Errorf("got %v, want 2 repos", got)
+	}
+	if got := selectSecurityRepos(config, "o/b"); len(got) != 1 || got[0] != "o/b" {
+		t.Errorf("got %v, want [o/b]", got)
+	}
+}

--- a/services/concurrent_github_service.go
+++ b/services/concurrent_github_service.go
@@ -226,6 +226,96 @@ func (c *ConcurrentGitHubService) stargazerWorker(ctx context.Context, wg *sync.
 	}
 }
 
+type AlertJob struct {
+	Owner string
+	Repo  string
+	Index int
+}
+
+type AlertResult struct {
+	Alerts []SecurityAlert
+	Index  int
+	Error  error
+}
+
+func (c *ConcurrentGitHubService) GetDependabotAlertsBatch(repos []string) ([][]SecurityAlert, []error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	jobs := make(chan AlertJob, len(repos))
+	results := make(chan AlertResult, len(repos))
+
+	var wg sync.WaitGroup
+	for i := 0; i < c.maxWorkers; i++ {
+		wg.Add(1)
+		go c.alertWorker(ctx, &wg, jobs, results)
+	}
+
+	go func() {
+		defer close(jobs)
+		for i, repoStr := range repos {
+			owner, repo, err := ParseRepoString(repoStr)
+			if err != nil {
+				results <- AlertResult{
+					Index: i,
+					Error: fmt.Errorf("invalid repo format %s: %w", repoStr, err),
+				}
+				continue
+			}
+			select {
+			case jobs <- AlertJob{Owner: owner, Repo: repo, Index: i}:
+			case <-ctx.Done():
+				results <- AlertResult{
+					Index: i,
+					Error: ctx.Err(),
+				}
+				return
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	alerts := make([][]SecurityAlert, len(repos))
+	errs := make([]error, len(repos))
+	for r := range results {
+		if r.Index < len(repos) {
+			alerts[r.Index] = r.Alerts
+			errs[r.Index] = r.Error
+		}
+	}
+
+	return alerts, errs
+}
+
+func (c *ConcurrentGitHubService) alertWorker(ctx context.Context, wg *sync.WaitGroup, jobs <-chan AlertJob, results chan<- AlertResult) {
+	defer wg.Done()
+
+	for {
+		select {
+		case job, ok := <-jobs:
+			if !ok {
+				return
+			}
+			raw, err := c.baseService.client.GetDependabotAlerts(ctx, job.Owner, job.Repo)
+			converted := make([]SecurityAlert, 0, len(raw))
+			for _, a := range raw {
+				converted = append(converted, toSecurityAlert(a))
+			}
+			results <- AlertResult{
+				Alerts: converted,
+				Index:  job.Index,
+				Error:  err,
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (c *ConcurrentGitHubService) SetMaxConcurrent(maxConcurrent int) {
 	if maxConcurrent <= 0 {
 		maxConcurrent = 10

--- a/services/github_client.go
+++ b/services/github_client.go
@@ -50,6 +50,27 @@ type UserAPIData struct {
 	Login string `json:"login"`
 }
 
+type DependabotAlertAPIData struct {
+	State            string `json:"state"`
+	SecurityAdvisory struct {
+		GHSAID string `json:"ghsa_id"`
+	} `json:"security_advisory"`
+	SecurityVulnerability struct {
+		Severity            string `json:"severity"`
+		VulnerableRange     string `json:"vulnerable_version_range"`
+		FirstPatchedVersion struct {
+			Identifier string `json:"identifier"`
+		} `json:"first_patched_version"`
+		Package struct {
+			Name      string `json:"name"`
+			Ecosystem string `json:"ecosystem"`
+		} `json:"package"`
+	} `json:"security_vulnerability"`
+	Dependency struct {
+		Scope string `json:"scope"`
+	} `json:"dependency"`
+}
+
 type GitHubAPIClientImpl struct {
 	client      *api.RESTClient
 	retryConfig RetryConfig

--- a/services/github_client.go
+++ b/services/github_client.go
@@ -11,6 +11,10 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 
+// ErrNoAlertAccess indicates the token cannot read Dependabot alerts for a repo
+// (un-owned repo, or alerts disabled). Treated as "skip", not a hard error.
+var ErrNoAlertAccess = errors.New("no access to dependabot alerts")
+
 type RepoAPIData struct {
 	Name            string    `json:"name"`
 	Owner           OwnerData `json:"owner"`
@@ -252,4 +256,73 @@ func (c *GitHubAPIClientImpl) GetStargazers(ctx context.Context, owner, repo str
 	}
 
 	return users, nil
+}
+
+func (c *GitHubAPIClientImpl) GetDependabotAlerts(ctx context.Context, owner, repo string) ([]DependabotAlertAPIData, error) {
+	path := fmt.Sprintf("repos/%s/%s/dependabot/alerts?state=open&per_page=100", owner, repo)
+	var all []DependabotAlertAPIData
+
+	for path != "" {
+		var page []DependabotAlertAPIData
+		next, err := c.getAlertsPage(ctx, path, &page)
+		if err != nil {
+			var httpErr *api.HTTPError
+			if errors.As(err, &httpErr) {
+				// A secondary rate-limit also surfaces as 403; that's transient, so
+				// propagate it rather than misreporting the repo as inaccessible.
+				if isSecondaryRateLimit(httpErr) {
+					return nil, err
+				}
+				if httpErr.StatusCode == 403 || httpErr.StatusCode == 404 {
+					return nil, ErrNoAlertAccess
+				}
+			}
+			var ghErr *GitHubError
+			if errors.As(err, &ghErr) && (ghErr.Type == ErrorTypeAuth || ghErr.Type == ErrorTypeNotFound) {
+				return nil, ErrNoAlertAccess
+			}
+			return nil, err
+		}
+		all = append(all, page...)
+		path = next
+	}
+
+	return all, nil
+}
+
+// isSecondaryRateLimit reports whether a 403 is a (transient) secondary rate
+// limit rather than a permanent access denial. GitHub signals this with a
+// Retry-After header and/or a "rate limit" message.
+func isSecondaryRateLimit(httpErr *api.HTTPError) bool {
+	if httpErr.StatusCode != 403 {
+		return false
+	}
+	if httpErr.Headers.Get("Retry-After") != "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(httpErr.Message), "rate limit")
+}
+
+func (c *GitHubAPIClientImpl) getAlertsPage(ctx context.Context, path string, result *[]DependabotAlertAPIData) (string, error) {
+	var nextPath string
+
+	err := WithRetry(ctx, c.retryConfig, func() error {
+		resp, err := c.client.RequestWithContext(ctx, "GET", path, nil)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		decoder := json.NewDecoder(resp.Body)
+		if err := decoder.Decode(result); err != nil {
+			return NewAPIError("failed to decode JSON response", resp.StatusCode, "", err)
+		}
+
+		nextPath = parseNextLink(resp.Header.Get("Link"))
+		return nil
+	})
+
+	return nextPath, err
 }

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -44,6 +44,10 @@ type StargazerBatchService interface {
 	GetStargazersBatch(repos []string) ([][]UserAPIData, []error)
 }
 
+type DependabotAlertsBatchService interface {
+	GetDependabotAlertsBatch(repos []string) ([][]SecurityAlert, []error)
+}
+
 type Output interface {
 	Printf(format string, args ...any)
 	Println(args ...any)

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -25,6 +25,7 @@ type GitHubAPIClient interface {
 	GetLatestRelease(ctx context.Context, owner, repo string) (*ReleaseAPIData, error)
 	CompareCommits(ctx context.Context, owner, repo, base, head string) (*CommitsComparisonAPIData, error)
 	GetStargazers(ctx context.Context, owner, repo string) ([]UserAPIData, error)
+	GetDependabotAlerts(ctx context.Context, owner, repo string) ([]DependabotAlertAPIData, error)
 }
 
 type GitHubService interface {

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -166,3 +166,28 @@ type Formatter interface {
 	RenderFans(result FansResult) error
 	RenderList(result ListResult) error
 }
+
+type SecurityAlert struct {
+	Severity     string `json:"severity"` // critical | high | medium | low
+	Ecosystem    string `json:"ecosystem"`
+	Package      string `json:"package"`
+	VulnRange    string `json:"vulnRange"`
+	FixedVersion string `json:"fixedVersion"`
+	GHSA         string `json:"ghsa"`
+	Scope        string `json:"scope"`
+}
+
+type SecurityRepoEntry struct {
+	Repo   string          `json:"repo"`
+	Total  int             `json:"total"`
+	Counts map[string]int  `json:"counts"`
+	Alerts []SecurityAlert `json:"alerts"`
+}
+
+type SecurityResult struct {
+	Repos        []SecurityRepoEntry `json:"repos"`
+	Totals       map[string]int      `json:"totals"`
+	GrandTotal   int                 `json:"grandTotal"`
+	WatchedCount int                 `json:"watchedCount"`
+	SkippedRepos []string            `json:"skippedRepos"`
+}

--- a/services/interfaces.go
+++ b/services/interfaces.go
@@ -170,6 +170,7 @@ type Formatter interface {
 	RenderReleases(releases []ReleaseInfo) error
 	RenderFans(result FansResult) error
 	RenderList(result ListResult) error
+	RenderSecurity(result SecurityResult, detail bool) error
 }
 
 type SecurityAlert struct {

--- a/services/json_formatter.go
+++ b/services/json_formatter.go
@@ -44,3 +44,16 @@ func (f *JSONFormatter) RenderList(result ListResult) error {
 	}
 	return json.NewEncoder(f.w).Encode(result)
 }
+
+func (f *JSONFormatter) RenderSecurity(result SecurityResult, _ bool) error {
+	if result.Repos == nil {
+		result.Repos = []SecurityRepoEntry{}
+	}
+	if result.SkippedRepos == nil {
+		result.SkippedRepos = []string{}
+	}
+	if result.Totals == nil {
+		result.Totals = map[string]int{}
+	}
+	return json.NewEncoder(f.w).Encode(result)
+}

--- a/services/json_formatter_test.go
+++ b/services/json_formatter_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -477,5 +478,20 @@ func assertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if expected != actual {
 		t.Errorf("expected %v (%T), got %v (%T)", expected, expected, actual, actual)
+	}
+}
+
+func TestJSONRenderSecurity_EmptySlicesNotNull(t *testing.T) {
+	var buf bytes.Buffer
+	f := NewJSONFormatter(&buf)
+	if err := f.RenderSecurity(SecurityResult{WatchedCount: 2}, false); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"repos":[]`) || !strings.Contains(out, `"skippedRepos":[]`) {
+		t.Errorf("expected empty arrays, got %s", out)
+	}
+	if !strings.Contains(out, `"totals":{}`) {
+		t.Errorf("expected empty totals object, got %s", out)
 	}
 }

--- a/services/mock/mock_interfaces.go
+++ b/services/mock/mock_interfaces.go
@@ -653,6 +653,20 @@ func (mr *MockFormatterMockRecorder) RenderReleases(releases any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderReleases", reflect.TypeOf((*MockFormatter)(nil).RenderReleases), releases)
 }
 
+// RenderSecurity mocks base method.
+func (m *MockFormatter) RenderSecurity(result services.SecurityResult, detail bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RenderSecurity", result, detail)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RenderSecurity indicates an expected call of RenderSecurity.
+func (mr *MockFormatterMockRecorder) RenderSecurity(result, detail any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenderSecurity", reflect.TypeOf((*MockFormatter)(nil).RenderSecurity), result, detail)
+}
+
 // RenderStatus mocks base method.
 func (m *MockFormatter) RenderStatus(entries []services.StatusEntry) error {
 	m.ctrl.T.Helper()

--- a/services/mock/mock_interfaces.go
+++ b/services/mock/mock_interfaces.go
@@ -477,6 +477,45 @@ func (mr *MockStargazerBatchServiceMockRecorder) GetStargazersBatch(repos any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStargazersBatch", reflect.TypeOf((*MockStargazerBatchService)(nil).GetStargazersBatch), repos)
 }
 
+// MockDependabotAlertsBatchService is a mock of DependabotAlertsBatchService interface.
+type MockDependabotAlertsBatchService struct {
+	ctrl     *gomock.Controller
+	recorder *MockDependabotAlertsBatchServiceMockRecorder
+	isgomock struct{}
+}
+
+// MockDependabotAlertsBatchServiceMockRecorder is the mock recorder for MockDependabotAlertsBatchService.
+type MockDependabotAlertsBatchServiceMockRecorder struct {
+	mock *MockDependabotAlertsBatchService
+}
+
+// NewMockDependabotAlertsBatchService creates a new mock instance.
+func NewMockDependabotAlertsBatchService(ctrl *gomock.Controller) *MockDependabotAlertsBatchService {
+	mock := &MockDependabotAlertsBatchService{ctrl: ctrl}
+	mock.recorder = &MockDependabotAlertsBatchServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDependabotAlertsBatchService) EXPECT() *MockDependabotAlertsBatchServiceMockRecorder {
+	return m.recorder
+}
+
+// GetDependabotAlertsBatch mocks base method.
+func (m *MockDependabotAlertsBatchService) GetDependabotAlertsBatch(repos []string) ([][]services.SecurityAlert, []error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDependabotAlertsBatch", repos)
+	ret0, _ := ret[0].([][]services.SecurityAlert)
+	ret1, _ := ret[1].([]error)
+	return ret0, ret1
+}
+
+// GetDependabotAlertsBatch indicates an expected call of GetDependabotAlertsBatch.
+func (mr *MockDependabotAlertsBatchServiceMockRecorder) GetDependabotAlertsBatch(repos any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDependabotAlertsBatch", reflect.TypeOf((*MockDependabotAlertsBatchService)(nil).GetDependabotAlertsBatch), repos)
+}
+
 // MockOutput is a mock of Output interface.
 type MockOutput struct {
 	ctrl     *gomock.Controller

--- a/services/mock/mock_interfaces.go
+++ b/services/mock/mock_interfaces.go
@@ -192,6 +192,21 @@ func (mr *MockGitHubAPIClientMockRecorder) Get(ctx, path, response any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockGitHubAPIClient)(nil).Get), ctx, path, response)
 }
 
+// GetDependabotAlerts mocks base method.
+func (m *MockGitHubAPIClient) GetDependabotAlerts(ctx context.Context, owner, repo string) ([]services.DependabotAlertAPIData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDependabotAlerts", ctx, owner, repo)
+	ret0, _ := ret[0].([]services.DependabotAlertAPIData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDependabotAlerts indicates an expected call of GetDependabotAlerts.
+func (mr *MockGitHubAPIClientMockRecorder) GetDependabotAlerts(ctx, owner, repo any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDependabotAlerts", reflect.TypeOf((*MockGitHubAPIClient)(nil).GetDependabotAlerts), ctx, owner, repo)
+}
+
 // GetLatestRelease mocks base method.
 func (m *MockGitHubAPIClient) GetLatestRelease(ctx context.Context, owner, repo string) (*services.ReleaseAPIData, error) {
 	m.ctrl.T.Helper()

--- a/services/plain_formatter.go
+++ b/services/plain_formatter.go
@@ -283,3 +283,88 @@ func (f *PlainFormatter) hasEvent(events []string, event string) bool {
 	}
 	return false
 }
+
+func (f *PlainFormatter) RenderSecurity(result SecurityResult, detail bool) error {
+	if result.GrandTotal == 0 {
+		if _, err := fmt.Fprintf(f.w, "✅ No open security alerts across %d watched repos.\n", result.WatchedCount); err != nil {
+			return err
+		}
+		return f.renderSecuritySkipped(result.SkippedRepos)
+	}
+
+	if _, err := fmt.Fprintln(f.w, "\n🔒 Security"); err != nil {
+		return err
+	}
+
+	if detail {
+		if err := f.renderSecurityDetail(result); err != nil {
+			return err
+		}
+	} else {
+		if err := f.renderSecurityTable(result); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(f.w, "\n 📊 Totals: 🔴 %d  🟠 %d  🟡 %d  ⚪ %d  (%d across %d repos)\n",
+		result.Totals["critical"], result.Totals["high"], result.Totals["medium"], result.Totals["low"],
+		result.GrandTotal, len(result.Repos)); err != nil {
+		return err
+	}
+
+	return f.renderSecuritySkipped(result.SkippedRepos)
+}
+
+func (f *PlainFormatter) renderSecurityTable(result SecurityResult) error {
+	tp := tableprinter.New(f.w, f.isTTY, f.maxWidth)
+	tp.AddHeader([]string{"Repo", "Total", "🔴", "🟠", "🟡", "⚪"})
+	for _, e := range result.Repos {
+		tp.AddField(e.Repo, tableprinter.WithColor(f.bold()))
+		tp.AddField(fmt.Sprintf("%d", e.Total))
+		tp.AddField(securityCountField(e.Counts["critical"]))
+		tp.AddField(securityCountField(e.Counts["high"]))
+		tp.AddField(securityCountField(e.Counts["medium"]))
+		tp.AddField(securityCountField(e.Counts["low"]))
+		tp.EndRow()
+	}
+	return tp.Render()
+}
+
+func (f *PlainFormatter) renderSecurityDetail(result SecurityResult) error {
+	for _, e := range result.Repos {
+		if _, err := fmt.Fprintf(f.w, "\n%s (%d)\n", e.Repo, e.Total); err != nil {
+			return err
+		}
+		for _, a := range e.Alerts {
+			fix := a.FixedVersion
+			if fix == "" {
+				fix = "no fix"
+			}
+			scope := a.Scope
+			if scope == "" {
+				scope = "?"
+			}
+			if _, err := fmt.Fprintf(f.w, "  [%s] %s/%s %s → %s [%s] %s\n",
+				a.Severity, a.Ecosystem, a.Package, a.VulnRange, fix, scope, a.GHSA); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *PlainFormatter) renderSecuritySkipped(skipped []string) error {
+	if len(skipped) == 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(f.w, " ⚠️  %d watched repo(s) skipped (no alert access): %s\n",
+		len(skipped), strings.Join(skipped, ", "))
+	return err
+}
+
+func securityCountField(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", n)
+}

--- a/services/plain_formatter_test.go
+++ b/services/plain_formatter_test.go
@@ -234,6 +234,59 @@ func TestPlainFormatter_RenderList(t *testing.T) {
 	}
 }
 
+func TestPlainRenderSecurity_AllClear(t *testing.T) {
+	var buf bytes.Buffer
+	f := NewPlainFormatter(&buf, false, 80)
+	if err := f.RenderSecurity(SecurityResult{WatchedCount: 5}, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No open security alerts across 5 watched repos") {
+		t.Errorf("missing all-clear message: %q", buf.String())
+	}
+}
+
+func TestPlainRenderSecurity_TableAndSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	f := NewPlainFormatter(&buf, false, 120)
+	res := SecurityResult{
+		Repos: []SecurityRepoEntry{
+			{Repo: "o/a", Total: 2, Counts: map[string]int{"critical": 1, "low": 1},
+				Alerts: []SecurityAlert{{Severity: "critical", Package: "log4j"}, {Severity: "low", Package: "zlib"}}},
+		},
+		Totals: map[string]int{"critical": 1, "low": 1}, GrandTotal: 2,
+		WatchedCount: 3, SkippedRepos: []string{"o/c"},
+	}
+	if err := f.RenderSecurity(res, false); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "o/a") {
+		t.Errorf("missing repo row: %q", out)
+	}
+	if !strings.Contains(out, "1 watched repo(s) skipped") {
+		t.Errorf("missing skipped footer: %q", out)
+	}
+}
+
+func TestPlainRenderSecurity_Detail(t *testing.T) {
+	var buf bytes.Buffer
+	f := NewPlainFormatter(&buf, false, 120)
+	res := SecurityResult{
+		Repos: []SecurityRepoEntry{
+			{Repo: "o/a", Total: 1, Counts: map[string]int{"high": 1},
+				Alerts: []SecurityAlert{{Severity: "high", Ecosystem: "pip", Package: "pygments",
+					VulnRange: "< 2.20.0", FixedVersion: "2.20.0", GHSA: "GHSA-x", Scope: "development"}}},
+		},
+		Totals: map[string]int{"high": 1}, GrandTotal: 1, WatchedCount: 1,
+	}
+	if err := f.RenderSecurity(res, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "pip/pygments < 2.20.0 → 2.20.0") {
+		t.Errorf("missing detail line: %q", buf.String())
+	}
+}
+
 func TestPlainFormatter_RenderReleases(t *testing.T) {
 	releases := []ReleaseInfo{
 		{

--- a/services/security_service.go
+++ b/services/security_service.go
@@ -1,6 +1,10 @@
 package services
 
-import "strings"
+import (
+	"errors"
+	"sort"
+	"strings"
+)
 
 func SeverityWeight(severity string) int {
 	switch strings.ToLower(severity) {
@@ -27,4 +31,77 @@ func toSecurityAlert(a DependabotAlertAPIData) SecurityAlert {
 		GHSA:         a.SecurityAdvisory.GHSAID,
 		Scope:        a.Dependency.Scope,
 	}
+}
+
+// BuildSecurityResult aggregates per-repo alerts into a ranked snapshot.
+// errs[i] == ErrNoAlertAccess routes a repo to SkippedRepos; any other non-nil
+// error excludes the repo silently (the caller is responsible for logging it).
+// severityFloor (""|low|medium|high|critical) drops alerts below that severity.
+func BuildSecurityResult(repos []string, alertsPerRepo [][]SecurityAlert, errs []error, severityFloor string) SecurityResult {
+	floor := SeverityWeight(severityFloor)
+	result := SecurityResult{
+		Totals:       map[string]int{},
+		WatchedCount: len(repos),
+	}
+
+	for i, repo := range repos {
+		if i < len(errs) && errs[i] != nil {
+			if errors.Is(errs[i], ErrNoAlertAccess) {
+				result.SkippedRepos = append(result.SkippedRepos, repo)
+			}
+			continue
+		}
+
+		counts := map[string]int{}
+		var filtered []SecurityAlert
+		for _, a := range alertsPerRepo[i] {
+			if SeverityWeight(a.Severity) < floor {
+				continue
+			}
+			sev := strings.ToLower(a.Severity)
+			filtered = append(filtered, a)
+			counts[sev]++
+			result.Totals[sev]++
+			result.GrandTotal++
+		}
+
+		if len(filtered) == 0 {
+			continue
+		}
+
+		sortAlerts(filtered)
+		result.Repos = append(result.Repos, SecurityRepoEntry{
+			Repo:   repo,
+			Total:  len(filtered),
+			Counts: counts,
+			Alerts: filtered,
+		})
+	}
+
+	sortSecurityRepos(result.Repos)
+	return result
+}
+
+func sortAlerts(alerts []SecurityAlert) {
+	sort.SliceStable(alerts, func(i, j int) bool {
+		wi, wj := SeverityWeight(alerts[i].Severity), SeverityWeight(alerts[j].Severity)
+		if wi != wj {
+			return wi > wj
+		}
+		return alerts[i].Package < alerts[j].Package
+	})
+}
+
+func sortSecurityRepos(repos []SecurityRepoEntry) {
+	sort.SliceStable(repos, func(i, j int) bool {
+		for _, sev := range []string{"critical", "high", "medium", "low"} {
+			if repos[i].Counts[sev] != repos[j].Counts[sev] {
+				return repos[i].Counts[sev] > repos[j].Counts[sev]
+			}
+		}
+		if repos[i].Total != repos[j].Total {
+			return repos[i].Total > repos[j].Total
+		}
+		return repos[i].Repo < repos[j].Repo
+	})
 }

--- a/services/security_service.go
+++ b/services/security_service.go
@@ -1,0 +1,30 @@
+package services
+
+import "strings"
+
+func SeverityWeight(severity string) int {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func toSecurityAlert(a DependabotAlertAPIData) SecurityAlert {
+	return SecurityAlert{
+		Severity:     a.SecurityVulnerability.Severity,
+		Ecosystem:    a.SecurityVulnerability.Package.Ecosystem,
+		Package:      a.SecurityVulnerability.Package.Name,
+		VulnRange:    a.SecurityVulnerability.VulnerableRange,
+		FixedVersion: a.SecurityVulnerability.FirstPatchedVersion.Identifier,
+		GHSA:         a.SecurityAdvisory.GHSAID,
+		Scope:        a.Dependency.Scope,
+	}
+}

--- a/services/security_service_test.go
+++ b/services/security_service_test.go
@@ -25,6 +25,69 @@ func TestSeverityWeight(t *testing.T) {
 	}
 }
 
+func sampleAlerts() [][]SecurityAlert {
+	return [][]SecurityAlert{
+		{ // repo 0: one high, one low
+			{Severity: "low", Package: "zlib"},
+			{Severity: "high", Package: "openssl"},
+		},
+		{ // repo 1: one critical
+			{Severity: "critical", Package: "log4j"},
+		},
+		nil, // repo 2: no access (see errs)
+	}
+}
+
+func TestBuildSecurityResult_RankingAndTotals(t *testing.T) {
+	repos := []string{"o/a", "o/b", "o/c"}
+	errs := []error{nil, nil, ErrNoAlertAccess}
+
+	res := BuildSecurityResult(repos, sampleAlerts(), errs, "")
+
+	if res.WatchedCount != 3 {
+		t.Errorf("WatchedCount = %d, want 3", res.WatchedCount)
+	}
+	if res.GrandTotal != 3 {
+		t.Errorf("GrandTotal = %d, want 3", res.GrandTotal)
+	}
+	if len(res.Repos) != 2 {
+		t.Fatalf("len(Repos) = %d, want 2", len(res.Repos))
+	}
+	if res.Repos[0].Repo != "o/b" {
+		t.Errorf("Repos[0] = %s, want o/b", res.Repos[0].Repo)
+	}
+	if res.Repos[1].Alerts[0].Severity != "high" {
+		t.Errorf("o/a first alert = %s, want high", res.Repos[1].Alerts[0].Severity)
+	}
+	if res.Totals["critical"] != 1 || res.Totals["high"] != 1 || res.Totals["low"] != 1 {
+		t.Errorf("Totals = %+v, want crit1 high1 low1", res.Totals)
+	}
+	if len(res.SkippedRepos) != 1 || res.SkippedRepos[0] != "o/c" {
+		t.Errorf("SkippedRepos = %v, want [o/c]", res.SkippedRepos)
+	}
+}
+
+func TestBuildSecurityResult_SeverityFloor(t *testing.T) {
+	repos := []string{"o/a", "o/b", "o/c"}
+	errs := []error{nil, nil, ErrNoAlertAccess}
+
+	res := BuildSecurityResult(repos, sampleAlerts(), errs, "high")
+
+	if res.GrandTotal != 2 {
+		t.Errorf("GrandTotal = %d, want 2", res.GrandTotal)
+	}
+	if len(res.Repos) != 2 {
+		t.Fatalf("len(Repos) = %d, want 2 (o/a keeps its high, o/b keeps its critical)", len(res.Repos))
+	}
+	for _, e := range res.Repos {
+		for _, a := range e.Alerts {
+			if SeverityWeight(a.Severity) < SeverityWeight("high") {
+				t.Errorf("alert below floor leaked: %+v", a)
+			}
+		}
+	}
+}
+
 func TestToSecurityAlert(t *testing.T) {
 	var raw DependabotAlertAPIData
 	raw.SecurityAdvisory.GHSAID = "GHSA-xxxx"

--- a/services/security_service_test.go
+++ b/services/security_service_test.go
@@ -1,0 +1,46 @@
+package services
+
+import "testing"
+
+func TestSeverityWeight(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"critical", "critical", 4},
+		{"high", "high", 3},
+		{"medium", "medium", 2},
+		{"low", "low", 1},
+		{"case insensitive", "CRITICAL", 4},
+		{"empty", "", 0},
+		{"unknown", "bogus", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SeverityWeight(tt.input); got != tt.want {
+				t.Errorf("SeverityWeight(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToSecurityAlert(t *testing.T) {
+	var raw DependabotAlertAPIData
+	raw.SecurityAdvisory.GHSAID = "GHSA-xxxx"
+	raw.SecurityVulnerability.Severity = "high"
+	raw.SecurityVulnerability.VulnerableRange = "< 2.20.0"
+	raw.SecurityVulnerability.FirstPatchedVersion.Identifier = "2.20.0"
+	raw.SecurityVulnerability.Package.Name = "pygments"
+	raw.SecurityVulnerability.Package.Ecosystem = "pip"
+	raw.Dependency.Scope = "development"
+
+	got := toSecurityAlert(raw)
+	want := SecurityAlert{
+		Severity: "high", Ecosystem: "pip", Package: "pygments",
+		VulnRange: "< 2.20.0", FixedVersion: "2.20.0", GHSA: "GHSA-xxxx", Scope: "development",
+	}
+	if got != want {
+		t.Errorf("toSecurityAlert() = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `gh oss-watch security` — a point-in-time snapshot of open Dependabot security alerts across your watch list, extending the tool from inbound community signals (stars/issues/PRs/forks/releases) to **maintenance health**.

- **Watch-list scoped** — scans your configured repos (no extra args); repos you can't read alerts on are listed as *skipped*, not errored.
- **Two-tier output** — severity-ranked summary table by default; `--detail` for per-alert lines (package, version range → fix, GHSA).
- **Flags** — `--detail/-d`, `--severity/-s` (floor filter: critical/high/medium/low), `--repo/-r` (single watched repo), plus `--format json`.
- **Stateless snapshot** — alerts are *state*, not events, so every run shows full current exposure (no since-last-check diffing).
- **REST + existing retry/concurrency** — fetched per-repo through the same bounded worker-pool + retry layer as the other commands (secondary-rate-limit 403s are propagated, not mis-skipped).

## Design / plan

Built from an approved spec + implementation plan (see `docs/superpowers/`), task-by-task with spec + code-quality review each step, plus a final holistic review.

## Architecture

- `services/security_service.go` — `SeverityWeight`, `toSecurityAlert`, `BuildSecurityResult` (filter + lexicographic-by-tier ranking)
- `services/github_client.go` — `GetDependabotAlerts` (paginated REST, `ErrNoAlertAccess`, rate-limit guard)
- `services/concurrent_github_service.go` — `GetDependabotAlertsBatch` worker pool (mirrors `GetStargazersBatch`)
- `services/{json,plain}_formatter.go` — `RenderSecurity`
- `cmd/security.go` — the command + flag validation

No new dependencies.

## Test Plan

- [x] `go build ./... && go test ./... && go vet ./...` — all green
- [x] Unit tests: severity weight, conversion, aggregation/ranking, severity floor, formatters (table/detail/all-clear/skipped/JSON), flag validation
- [x] Manual smoke test against real repos: summary, `--detail`, `--severity`, `--repo`, `--format json`, and error paths (invalid severity, un-watched repo) all verified