### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/gh-oss-watch
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/cli/go-gh/v2 v2.13.0


### PR DESCRIPTION
Bump Go version from 1.26.1 to 1.26.5.

Go 1.26.5 (2026-07-07) includes security fixes to:
- crypto/tls
- os

Local verification:
- `go mod tidy` clean
- `go test ./...` all pass on macOS/arm64