### PR TITLE
docs: align README badges (drop retired Go Report Card)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # OSS Watch 📊
 
-[![Test](https://github.com/jackchuka/gh-oss-watch/workflows/Test/badge.svg)](https://github.com/jackchuka/gh-oss-watch/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jackchuka/gh-oss-watch)](https://goreportcard.com/report/github.com/jackchuka/gh-oss-watch)
+[![Test](https://github.com/jackchuka/gh-oss-watch/actions/workflows/test.yml/badge.svg)](https://github.com/jackchuka/gh-oss-watch/actions/workflows/test.yml)
+[![Release](https://img.shields.io/github/v/release/jackchuka/gh-oss-watch?sort=semver)](https://github.com/jackchuka/gh-oss-watch/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A GitHub CLI plugin that helps open-source maintainers stay on top of repository activity across multiple projects. Track stars, issues, pull requests, and more — all from your terminal.
 


### PR DESCRIPTION
## Why

[Go Report Card](https://goreportcard.com/sunset/) was sunset on **2026-07-01** and
[gojp/goreportcard](https://github.com/gojp/goreportcard) is now archived read-only.
The badge endpoint still returns 200 but serves a static SVG reading **`go report: retired`**,
so every README carrying it currently advertises a dead service.

While removing it, this aligns the badge block across all 20 public Go repos, which had
drifted into 3 different orders, 2 CI-badge URL forms, 3 license-badge variants, and
5 repos with no badges at all.

## Canonical block

- **Test** (or **CI**), **Release**, **License: MIT** — in that order
- current `/actions/workflows/<file>/badge.svg` form, replacing the deprecated
  `/workflows/<name>/badge.svg` path
- **Go Reference** only for repos exposing an importable public API
  (`go-xcache`, `proto-migrate`) — the other 18 keep all code in `internal/`
- license badge normalized to `License-MIT-blue`

Every repo is MIT, has published releases, and has a test workflow, so all three
badges resolve everywhere.

## Notes

- Docs only — no code, no workflow files touched.
- `postura` keeps its centered HTML badge row; `gv` keeps its centered layout.
- `tfpacker` keeps the `CI` label since its workflow is `ci.yml` named `CI`.